### PR TITLE
Update Keys.podspec

### DIFF
--- a/Keys.podspec
+++ b/Keys.podspec
@@ -13,7 +13,6 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/ashfurrow/empty-podspec"
   s.license      = { :type => "MIT (does not apply to anything but podspec)", :file => "LICENSE" }
   s.author             = { "Ash Furrow" => "ash@ashfurrow.com" }
-  s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/ashfurrow/empty-podspec.git", :tag => s.version }
   s.source_files  = "%%SOURCE_FILES%%"
   s.prepare_command = %Q[pod keys generate "%%PROJECT_NAME%%"]


### PR DESCRIPTION
Removes the platform, therefore making it multi platform - fixes https://github.com/orta/cocoapods-keys/issues/53
